### PR TITLE
fix button example

### DIFF
--- a/src/Buttons.md
+++ b/src/Buttons.md
@@ -109,7 +109,7 @@ fn main() {
             println!("btn1 is checked");
         }
         if btn2.value() {
-            println!("btn1 is checked");
+            println!("btn2 is checked");
         }
     });
 


### PR DESCRIPTION
Fixes button example. `if` evaluates if `btn2.value()` is `true` but mistakenly `println!`s `btn1 is checked` instead of `btn2 is checked` after proving `true`.