### PR TITLE
Fix image placement in generated docs

### DIFF
--- a/src/Buttons.md
+++ b/src/Buttons.md
@@ -52,6 +52,7 @@ fn main() {
 ```
 
 (The focus box can be removed using the clear_visible_focus() method `btn1.clear_visible_focus()`).
+
 ![image](https://user-images.githubusercontent.com/37966791/145727291-8be40de6-8ec6-4e57-bb29-fa0f0ac3b251.png)
 
 Other toggle-able buttons don't have this property.


### PR DESCRIPTION
There was no line break after line 54 (before an image was embedded). This caused the image, in the generated documents, to be placed before the code "`btn1.clear_visible_focus()`".

Before:
![image](https://user-images.githubusercontent.com/65889943/193707323-be63c443-4858-46f8-93c3-f672838bca62.png)

After:
![image](https://user-images.githubusercontent.com/65889943/193707291-a22d3501-5d41-43f1-ae3f-18cee262428a.png)

