### PR TITLE
typo correction

### DIFF
--- a/docs/Dialogs.html
+++ b/docs/Dialogs.html
@@ -374,7 +374,7 @@ fn main() {
         dialog::message(100, 100, "Message");
     });
 <span class="boring">}</span></code></pre></pre>
-<p>All the previously mentioned functions have to variants, one with _default() suffix which doesn't require coordinates, and the other without which requires coordinates.
+<p>All the previously mentioned functions have 2 variants, one with _default() suffix which doesn't require coordinates, and the other without which requires coordinates.
 Some dialogs return a value, like choice, input, and password. Input and password return the inputted text, while choice returns an index of the chosen value:</p>
 <pre><pre class="playground"><code class="language-rust edition2021">use fltk::{prelude::*, *};
 


### PR DESCRIPTION
Nothing much to say; it's a single word replacement for a typo from "to" to "2". I chose digit instead word "two", because it makes it easier to read in my opinion.