### PR TITLE
Layouts.md: forgotten group and unneeded mut

### DIFF
--- a/src/Layouts.md
+++ b/src/Layouts.md
@@ -14,11 +14,11 @@ use fltk::{prelude::*, *};
 fn main() {
     let a = app::App::default().with_scheme(app::Scheme::Gtk);
     let mut win = window::Window::default().with_size(400, 300);
-    let mut flex = Flex::new(0, 0, 400, 300, None);
+    let mut flex = group::Flex::new(0, 0, 400, 300, None);
     flex.set_type(group::FlexType::Column);
     let expanding = button::Button::default().with_label("Expanding");
-    let mut normal = button::Button::default().with_label("Normal");
-    flex.fixed(&mut normal, 30);
+    let normal = button::Button::default().with_label("Normal");
+    flex.fixed(&normal, 30);
     flex.end();
     win.end();
     win.show();


### PR DESCRIPTION
One command is missing the `group::`, as it's not imported and program would not compile. Also removed mutability for `normal` variable, as it's not changing anyway.