### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Mohammed Alyousef"]
 language = "en"
-multilingual = false
 src = "src"
 title = "fltk book"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10